### PR TITLE
feat: Adds support for custom HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,27 +28,28 @@ wmetrics [options] [http[s]://]hostname[:port][/path]
 ```
 
 ## Options
-| Option | Description |
-|--------| ----------- |
-| -4     | Resolve IPv4 addresses only (default true). |
-| -6     | Resolve IPv6 addresses only. |
-| -C file | Client PEM certificate file. |
-| -F string | Form data. |
-| -O format | Output format (std, text, json) (default "std"). |
-| -P URL | Use a proxy (complete URL or "host[:port]"). Supported schemes: "http," "https," and "socks5." |
-| -T string | Content type (default "application/json"). |
-| -c requests | Number of concurrent requests (default 1). |
-| -d string | Post data as a string. |
-| -f file | Post data from a file. |
-| -i | Allow insecure SSL connections. |
-| -k | Use HTTP KeepAlive feature. |
-| -km connections | Max idle connections (default 100). |
-| -kt timeout | Max idle connections timeout in ms (default 1m30s). |
-| -m method | HTTP method (default "GET"). |
-| -n requests | Number of requests to perform (default 1). |
-| -s Milliseconds | Maximum wait time for each response (default 30s). |
-| -tt timeout | TLS handshake timeout in ms (default 10s). |
-| -u User Agent | User Agent (default "wmetrics/v0.0.1"). |
+| Option | Description                                                                                                                               |
+|--------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| -4     | Resolve IPv4 addresses only (default true).                                                                                               |
+| -6     | Resolve IPv6 addresses only.                                                                                                              |
+| -C file | Client PEM certificate file.                                                                                                              |
+| -F string | Form data.                                                                                                                                |
+| -H header | Custom header. For example: "Accept-Encoding: gzip, deflate". Multiple headers can be provided with multiple -H flags. |
+| -O format | Output format (std, text, json) (default "std").                                                                                          |
+| -P URL | Use a proxy (complete URL or "host[:port]"). Supported schemes: "http," "https," and "socks5."                                            |
+| -T string | Content type (default "application/json").                                                                                                |
+| -c requests | Number of concurrent requests (default 1).                                                                                                |
+| -d string | Post data as a string.                                                                                                                    |
+| -f file | Post data from a file.                                                                                                                    |
+| -i | Allow insecure SSL connections.                                                                                                           |
+| -k | Use HTTP KeepAlive feature.                                                                                                               |
+| -km connections | Max idle connections (default 100).                                                                                                       |
+| -kt timeout | Max idle connections timeout in ms (default 1m30s).                                                                                       |
+| -m method | HTTP method (default "GET").                                                                                                              |
+| -n requests | Number of requests to perform (default 1).                                                                                                |
+| -s Milliseconds | Maximum wait time for each response (default 30s).                                                                                        |
+| -tt timeout | TLS handshake timeout in ms (default 10s).                                                                                                |
+| -u User Agent | User Agent (default "wmetrics/v0.0.1").                                                                                                   |
 | -ut User Agent Template | Use User Agent Template. Allowed values (chrome, firefox, edge)[-(linux, mac, android, iphone, ipod, ipad)]. Use -ut list to see all templates. |
 
 

--- a/main.go
+++ b/main.go
@@ -111,6 +111,7 @@ func getCLIParameters() tester.Parameters {
 		ContentType:           *arguments.ContentType.Value,
 		FormData:              *arguments.FormData.Value,
 		OutputFormat:          *arguments.OutputFormat.Value,
+		CustomHeaders:         *arguments.CustomHeaders.Value,
 	}
 }
 

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -5,8 +5,16 @@ import (
 	"fmt"
 	"github.com/vpominchuk/wmetrics/src/app"
 	"github.com/vpominchuk/wmetrics/src/formatter"
+	"strings"
 	"time"
 )
+
+type stringArrayArgument struct {
+	Name         string
+	help         string
+	defaultValue []string
+	Value        *[]string
+}
 
 type stringArgument struct {
 	Name         string
@@ -57,6 +65,18 @@ type Arguments struct {
 	ContentType           stringArgument
 	FormData              stringArgument
 	OutputFormat          stringArgument
+	CustomHeaders         stringArrayArgument
+}
+
+type multipleStringValues []string
+
+func (s *multipleStringValues) String() string {
+	return strings.Join(*s, "\n")
+}
+
+func (s *multipleStringValues) Set(value string) error {
+	*s = append(*s, value)
+	return nil
 }
 
 var arguments = Arguments{
@@ -159,6 +179,12 @@ var arguments = Arguments{
 		Name: "O", defaultValue: "std",
 		help: "Output `format`. Allowed values (std, text, json)",
 	},
+
+	CustomHeaders: stringArrayArgument{
+		Name: "H", defaultValue: nil,
+		help: "Custom `header`. For example: \"Accept-Encoding: gzip, deflate\"." +
+			" Multiple headers can be provided with multiple -H flags.",
+	},
 }
 
 func (arguments *Arguments) init() {
@@ -248,6 +274,10 @@ func (arguments *Arguments) init() {
 		arguments.OutputFormat.Name, arguments.OutputFormat.defaultValue,
 		arguments.OutputFormat.help,
 	)
+
+	var headers multipleStringValues
+	flag.Var(&headers, arguments.CustomHeaders.Name, arguments.CustomHeaders.help)
+	arguments.CustomHeaders.Value = (*[]string)(&headers)
 
 	flag.Usage = customUsage
 

--- a/src/tester/httpEngine.go
+++ b/src/tester/httpEngine.go
@@ -158,6 +158,14 @@ func (engine *HttpEngine) setHeaders(parameters Parameters, request *http.Reques
 	if parameters.FormData != "" {
 		request.Header.Set("content-type", "application/x-www-form-urlencoded")
 	}
+
+	if parameters.CustomHeaders != nil && len(parameters.CustomHeaders) > 0 {
+		for _, header := range parameters.CustomHeaders {
+			headerParts := strings.SplitN(header, ":", 2)
+
+			request.Header.Set(headerParts[0], headerParts[1])
+		}
+	}
 }
 
 func (engine *HttpEngine) newClient(parameters Parameters, requestHost string) *http.Client {

--- a/src/tester/types.go
+++ b/src/tester/types.go
@@ -29,6 +29,7 @@ type Parameters struct {
 	ContentType           string
 	FormData              string
 	OutputFormat          string
+	CustomHeaders         []string
 }
 
 type TestEngine interface {


### PR DESCRIPTION
Adds support for custom HTTP headers.

Adds new CLI option:
`-H header      Custom header. For example: "Accept-Encoding: gzip, deflate". Multiple headers can be provided with multiple -H flags.`

Documentation has been updated.
