### PR TITLE
Adds support for test timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,28 +38,29 @@ wmetrics [options] [http[s]://]hostname[:port][/path]
 ```
 
 ## Options
-| Option | Description                                                                                                                               |
-|--------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| -4     | Resolve IPv4 addresses only (default true).                                                                                               |
-| -6     | Resolve IPv6 addresses only.                                                                                                              |
-| -C file | Client PEM certificate file.                                                                                                              |
-| -F string | Form data.                                                                                                                                |
-| -H header | Custom header. For example: "Accept-Encoding: gzip, deflate". Multiple headers can be provided with multiple -H flags. |
-| -O format | Output format (std, text, json) (default "std").                                                                                          |
-| -P URL | Use a proxy (complete URL or "host[:port]"). Supported schemes: "http," "https," and "socks5."                                            |
-| -T string | Content type (default "application/json").                                                                                                |
-| -c requests | Number of concurrent requests (default 1).                                                                                                |
-| -d string | Post data as a string.                                                                                                                    |
-| -f file | Post data from a file.                                                                                                                    |
-| -i | Allow insecure SSL connections.                                                                                                           |
-| -k | Use HTTP KeepAlive feature.                                                                                                               |
-| -km connections | Max idle connections (default 100).                                                                                                       |
-| -kt timeout | Max idle connections timeout in ms (default 1m30s).                                                                                       |
-| -m method | HTTP method (default "GET").                                                                                                              |
-| -n requests | Number of requests to perform (default 1).                                                                                                |
-| -s Milliseconds | Maximum wait time for each response (default 30s).                                                                                        |
-| -tt timeout | TLS handshake timeout in ms (default 10s).                                                                                                |
-| -u User Agent | User Agent (default "wmetrics/v0.0.1").                                                                                                   |
+| Option | Description                                                                                                                                     |
+|--------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| -4     | Resolve IPv4 addresses only (default true).                                                                                                     |
+| -6     | Resolve IPv6 addresses only.                                                                                                                    |
+| -C file | Client PEM certificate file.                                                                                                                    |
+| -F string | Form data.                                                                                                                                      |
+| -H header | Custom header. For example: "Accept-Encoding: gzip, deflate". Multiple headers can be provided with multiple -H flags.                          |
+| -O format | Output format (std, text, json) (default "std").                                                                                                |
+| -P URL | Use a proxy (complete URL or "host[:port]"). Supported schemes: "http," "https," and "socks5."                                                  |
+| -T string | Content type (default "application/json").                                                                                                      |
+| -c requests | Number of concurrent requests (default 1).                                                                                                      |
+| -d string | Post data as a string.                                                                                                                          |
+| -f file | Post data from a file.                                                                                                                          |
+| -i | Allow insecure SSL connections.                                                                                                                 |
+| -k | Use HTTP KeepAlive feature.                                                                                                                     |
+| -km connections | Max idle connections (default 100).                                                                                                             |
+| -kt timeout | Max idle connections timeout in ms (default 1m30s).                                                                                             |
+| -m method | HTTP method (default "GET").                                                                                                                    |
+| -n requests | Number of requests to perform (default 1).                                                                                                      |
+| -s Milliseconds | Maximum wait time for each response (default 30s).                                                                                              |
+| -t time | Time limit (1s, 200ms, ...). If the time limit is reached, wmetrics will interrupt the test and print the results.                              |
+| -tt timeout | TLS handshake timeout in ms (default 10s).                                                                                                      |
+| -u User Agent | User Agent (default "wmetrics/v0.0.1").                                                                                                         |
 | -ut User Agent Template | Use User Agent Template. Allowed values (chrome, firefox, edge)[-(linux, mac, android, iphone, ipod, ipad)]. Use -ut list to see all templates. |
 
 

--- a/main.go
+++ b/main.go
@@ -112,12 +112,19 @@ func getCLIParameters() tester.Parameters {
 		FormData:              *arguments.FormData.Value,
 		OutputFormat:          *arguments.OutputFormat.Value,
 		CustomHeaders:         *arguments.CustomHeaders.Value,
+		TimeLimit:             *arguments.TimeLimit.Value,
 	}
 }
 
 func buildProgressBar(parameters tester.Parameters) *progressbar.ProgressBar {
+	progressBarMax := parameters.Requests
+
+	if parameters.TimeLimit > 0 {
+		progressBarMax = -1
+	}
+
 	return progressbar.NewOptions(
-		parameters.Requests,
+		progressBarMax,
 		progressbar.OptionFullWidth(),
 		progressbar.OptionShowCount(),
 	)
@@ -126,11 +133,21 @@ func buildProgressBar(parameters tester.Parameters) *progressbar.ProgressBar {
 func showGreetings(parameters tester.Parameters) {
 	fmt.Printf("%s %s\n", app.ExecutableName, app.VersionString)
 	fmt.Printf("Copyright %d Vasyl Pominchuk\n", time.Now().Year())
-	fmt.Printf(
-		"Performing %d requests with concurrency level of %d\n",
-		parameters.Requests,
-		parameters.Concurrency,
-	)
+
+	if parameters.TimeLimit > 0 {
+		fmt.Printf(
+			"Performing requests with concurrency level of %d with time limit of %s\n",
+			parameters.Concurrency,
+			parameters.TimeLimit,
+		)
+	} else {
+		fmt.Printf(
+			"Performing %d requests with concurrency level of %d\n",
+			parameters.Requests,
+			parameters.Concurrency,
+		)
+	}
+
 	fmt.Printf(
 		"%s %s\n",
 		parameters.Method,

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -66,6 +66,7 @@ type Arguments struct {
 	FormData              stringArgument
 	OutputFormat          stringArgument
 	CustomHeaders         stringArrayArgument
+	TimeLimit             durationArgument
 }
 
 type multipleStringValues []string
@@ -92,7 +93,7 @@ var arguments = Arguments{
 
 	Timeout: durationArgument{
 		Name: "s", defaultValue: 30 * time.Second,
-		help: "`Milliseconds` to max. wait for each response.",
+		help: "`time` (30s, 800ms, ...) to max. wait for each response",
 	},
 
 	Method: stringArgument{
@@ -122,7 +123,7 @@ var arguments = Arguments{
 
 	IdleConnTimeout: durationArgument{
 		Name: "kt", defaultValue: 90 * time.Second,
-		help: "Max idle connections `timeout` in ms",
+		help: "Max idle connections `timeout` (90s, 800ms, ...)",
 	},
 
 	Proxy: stringArgument{
@@ -132,7 +133,7 @@ var arguments = Arguments{
 
 	TLSHandshakeTimeout: durationArgument{
 		Name: "tt", defaultValue: 10 * time.Second,
-		help: "TLS handshake `timeout` in ms",
+		help: "TLS handshake `timeout` (10s, 800ms, ...)",
 	},
 
 	IPv4Only: boolArgument{
@@ -184,6 +185,12 @@ var arguments = Arguments{
 		Name: "H", defaultValue: nil,
 		help: "Custom `header`. For example: \"Accept-Encoding: gzip, deflate\"." +
 			" Multiple headers can be provided with multiple -H flags.",
+	},
+
+	TimeLimit: durationArgument{
+		Name: "t", defaultValue: 0,
+		help: "`Time` limit (1s, 200ms, ...). If the time limit is reached, " + app.ExecutableName +
+			" will interrupt the test and print the results.",
 	},
 }
 
@@ -278,6 +285,11 @@ func (arguments *Arguments) init() {
 	var headers multipleStringValues
 	flag.Var(&headers, arguments.CustomHeaders.Name, arguments.CustomHeaders.help)
 	arguments.CustomHeaders.Value = (*[]string)(&headers)
+
+	arguments.TimeLimit.Value = flag.Duration(
+		arguments.TimeLimit.Name, arguments.TimeLimit.defaultValue,
+		arguments.TimeLimit.help,
+	)
 
 	flag.Usage = customUsage
 

--- a/src/args/validator.go
+++ b/src/args/validator.go
@@ -15,7 +15,7 @@ func Validate(arguments Arguments) error {
 		return fmt.Errorf("post data can only be specified once")
 	}
 
-	if *arguments.Requests.Value < *arguments.Concurrency.Value {
+	if *arguments.TimeLimit.Value == 0 && *arguments.Requests.Value < *arguments.Concurrency.Value {
 		return fmt.Errorf("cannot use concurrency level greater than total number of requests")
 	}
 

--- a/src/tester/types.go
+++ b/src/tester/types.go
@@ -30,6 +30,7 @@ type Parameters struct {
 	FormData              string
 	OutputFormat          string
 	CustomHeaders         []string
+	TimeLimit             time.Duration
 }
 
 type TestEngine interface {


### PR DESCRIPTION
## Adds support for test timeout. 
Adds new option (-t time)
-t time       Time limit (1s, 200ms, ...). If the time limit is reached, wmetrics will interrupt the test and print the results

Documentation has been updated.