### PR TITLE
Adds support for multiple URL tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To build the project for different platforms and architectures please follow our
 
 ## Usage
 ```bash
-wmetrics [options] [http[s]://]hostname[:port][/path]
+wmetrics [options] URL_LIST
 ```
 
 ## Options

--- a/main.go
+++ b/main.go
@@ -85,20 +85,29 @@ func getCLIParameters() tester.Parameters {
 		os.Exit(1)
 	}
 
-	if len(args) == 0 || len(args) > 1 {
+	if len(args) == 0 {
 		commandLine.Usage()
 		os.Exit(1)
 	}
 
-	parsedUrl, err := url.Parse(args[0])
+	resources := make([]tester.Resource, 0, len(args))
 
-	if err != nil {
-		log.Fatalf("Error: %v\n", err)
+	for _, link := range args {
+		parsedUrl, err := url.Parse(link)
+
+		if err != nil {
+			log.Fatalf("Error: %v\n", err)
+		}
+
+		resources = append(
+			resources, tester.Resource{
+				Url: parsedUrl,
+			},
+		)
 	}
 
 	return tester.Parameters{
-		Resource:              args[0],
-		Url:                   parsedUrl,
+		Resources:             resources,
 		Requests:              *arguments.Requests.Value,
 		Concurrency:           *arguments.Concurrency.Value,
 		Timeout:               *arguments.Timeout.Value,
@@ -156,11 +165,13 @@ func showGreetings(parameters tester.Parameters) {
 		)
 	}
 
-	fmt.Printf(
-		"%s %s\n",
-		parameters.Method,
-		parameters.Resource,
-	)
+	fmt.Printf("%s", parameters.Method)
+
+	if parameters.Resources != nil && len(parameters.Resources) > 1 {
+		fmt.Printf(" %s\n", parameters.Resources[0].Url.String())
+	} else {
+		fmt.Printf(" List of URLs\n")
+	}
 
 	fmt.Printf("\n")
 }

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -307,7 +307,7 @@ func Usage() {
 
 func customUsage() {
 	fmt.Fprintf(
-		flag.CommandLine.Output(), "Usage: %s [options] http[s]://]hostname[:port][/path]\n", app.ExecutableName,
+		flag.CommandLine.Output(), "Usage: %s [options] URL_LIST\n", app.ExecutableName,
 	)
 	fmt.Fprint(flag.CommandLine.Output(), "Options are:\n")
 	customPrintDefaults()

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -178,7 +178,7 @@ var arguments = Arguments{
 
 	OutputFormat: stringArgument{
 		Name: "O", defaultValue: "std",
-		help: "Output `format`. Allowed values (std, text, json)",
+		help: "Output `format`. Allowed values (std, text, json, json-pretty)",
 	},
 
 	CustomHeaders: stringArrayArgument{

--- a/src/formatter/formatter.go
+++ b/src/formatter/formatter.go
@@ -27,7 +27,26 @@ func PrintJsonResults(stat statistics.Statistics, pretty bool) {
 	fmt.Println(string(jsonData))
 }
 
-func PrintResults(stat statistics.Statistics) {
+func printTitle(title string) {
+	fmt.Println(title + ":")
+}
+
+func PrintResults(stats statistics.Statistics) {
+	urlNum := 0
+
+	for url, stat := range stats {
+		printTitle(url)
+		printSingleUrlResults(stat)
+
+		if urlNum < len(stats)-1 {
+			fmt.Print("─────────────────────────────────────────────────────────────────────────────────────\n\n")
+		}
+
+		urlNum++
+	}
+}
+
+func printSingleUrlResults(stat statistics.SingleUrlStatistics) {
 	strLength := 30
 
 	if stat.Server != "" {

--- a/src/tester/tester.go
+++ b/src/tester/tester.go
@@ -13,12 +13,40 @@ var testers = map[string]TestEngine{
 func Test(parameters Parameters, onProgress func(progress RequestsProgress)) (
 	[]MeasurementResult, time.Duration, error,
 ) {
-	testService, ok := testers[parameters.Url.Scheme]
+	testService, ok := testers[parameters.Resources[0].Url.Scheme]
+
+	resourceFeeder := newResourceFeeder(parameters.Resources)
 
 	if ok {
-		measurementResult, duration := testService.Measure(parameters, onProgress)
+		measurementResult, duration := testService.Measure(parameters, resourceFeeder, onProgress)
 		return measurementResult, duration, nil
 	}
 
 	return []MeasurementResult{}, 0, errors.New("unsupported protocol")
+}
+
+func newResourceFeeder(resources []Resource) *ResourceFeeder {
+	return &ResourceFeeder{
+		Resources: resources,
+		index:     0,
+	}
+}
+
+func (s *ResourceFeeder) GetNextValue() (Resource, error) {
+	if len(s.Resources) == 0 {
+		return Resource{}, errors.New("url list is empty. No resources to test")
+	}
+
+	if len(s.Resources) == 1 {
+		return s.Resources[0], nil
+	}
+
+	value := s.Resources[s.index]
+	s.index++
+
+	if s.index >= len(s.Resources) {
+		s.index = 0
+	}
+
+	return value, nil
 }

--- a/src/tester/types.go
+++ b/src/tester/types.go
@@ -6,9 +6,12 @@ import (
 	"time"
 )
 
+type Resource struct {
+	Url *url.URL
+}
+
 type Parameters struct {
-	Resource              string
-	Url                   *url.URL
+	Resources             []Resource
 	Requests              int
 	Concurrency           int
 	Timeout               time.Duration
@@ -34,7 +37,12 @@ type Parameters struct {
 }
 
 type TestEngine interface {
-	Measure(parameters Parameters, onProgress func(progress RequestsProgress)) ([]MeasurementResult, time.Duration)
+	Measure(
+		parameters Parameters,
+		resourceFeeder *ResourceFeeder,
+		onProgress func(progress RequestsProgress),
+	) ([]MeasurementResult, time.Duration)
+
 	GetProgress() RequestsProgress
 }
 
@@ -82,6 +90,7 @@ type ResponseHeaders struct {
 }
 
 type RequestResult struct {
+	Resource      Resource
 	Status        string // e.g. "200 OK"
 	StatusCode    int    // e.g. 200
 	ContentLength int64
@@ -99,4 +108,9 @@ func (result RequestResult) ToJson() ([]byte, error) {
 type MeasurementResult struct {
 	RequestResult RequestResult
 	Error         error
+}
+
+type ResourceFeeder struct {
+	Resources []Resource
+	index     int
 }


### PR DESCRIPTION
Adds support for multiple URL tests.

```
wmetrics [options] URL_LIST
```

`-n requests` - the number of requests will be divided by the number of URLs.

```
wmetrics -c 10 -n 100 https://google.com https://amazon.com
```
Each URL will be tested 50 times with concurrency level of 10.