### PR TITLE
Exit with exit code 1 on certain HTTP codes or connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ wmetrics [options] URL_LIST
 | -T string               | Content type (default "application/json").                                                                                                      |
 | -c requests             | Number of concurrent requests (default 1).                                                                                                      |
 | -d string               | Post data as a string.                                                                                                                          |
+| -e code                 | Exit with error on HTTP code. Multiple code can be provided with multiple -e flags.                                                             |
 | -f file                 | Post data from a file.                                                                                                                          |
 | -i                      | Allow insecure SSL connections.                                                                                                                 |
 | -k                      | Use HTTP KeepAlive feature.                                                                                                                     |

--- a/main.go
+++ b/main.go
@@ -35,7 +35,11 @@ func main() {
 		parameters,
 		func(progress tester.RequestsProgress) {
 			if bar != nil {
-				bar.Set(progress.CompletedRequests)
+				err := bar.Set(progress.CompletedRequests)
+
+				if err != nil {
+					return
+				}
 			}
 		},
 	)
@@ -59,6 +63,22 @@ func main() {
 	if canPrintGreetings(parameters.OutputFormat) {
 		fmt.Printf("\n")
 	}
+
+	if haveErrors(stat) {
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+func haveErrors(stat statistics.Statistics) bool {
+	for _, singleUrlStat := range stat {
+		if len(singleUrlStat.Errors) > 0 {
+			return true
+		}
+	}
+
+	return false
 }
 
 func canPrintProgressBar(format string) bool {
@@ -143,11 +163,12 @@ func getCLIParameters() tester.Parameters {
 		OutputFormat:          *arguments.OutputFormat.Value,
 		CustomHeaders:         *arguments.CustomHeaders.Value,
 		TimeLimit:             *arguments.TimeLimit.Value,
+		ExitWithErrorOnCode:   *arguments.ExitWithErrorOnCode.Value,
 	}
 }
 
 func stdError(message string) {
-	fmt.Fprintf(os.Stderr, message)
+	fmt.Fprint(os.Stderr, message)
 }
 
 func correctNumberOfRequests(parameters *tester.Parameters) {

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -68,6 +68,7 @@ type Arguments struct {
 	CustomHeaders         stringArrayArgument
 	TimeLimit             durationArgument
 	URLListFile           stringArgument
+	ExitWithErrorOnCode   stringArrayArgument
 }
 
 type multipleStringValues []string
@@ -198,6 +199,11 @@ var arguments = Arguments{
 		Name: "l", defaultValue: "",
 		help: "Path to a `file` with list of URLs",
 	},
+
+	ExitWithErrorOnCode: stringArrayArgument{
+		Name: "e", defaultValue: nil,
+		help: "Exit with error on HTTP `code`. Multiple codes can be provided with multiple -e flags. Example: -e 403 -e 3xx.",
+	},
 }
 
 func (arguments *Arguments) init() {
@@ -301,6 +307,10 @@ func (arguments *Arguments) init() {
 		arguments.TimeLimit.Name, arguments.TimeLimit.defaultValue,
 		arguments.TimeLimit.help,
 	)
+
+	var exitWithErrorOnCode multipleStringValues
+	flag.Var(&exitWithErrorOnCode, arguments.ExitWithErrorOnCode.Name, arguments.ExitWithErrorOnCode.help)
+	arguments.ExitWithErrorOnCode.Value = (*[]string)(&exitWithErrorOnCode)
 
 	flag.Usage = customUsage
 

--- a/src/args/validator.go
+++ b/src/args/validator.go
@@ -5,6 +5,7 @@ import (
 	"github.com/vpominchuk/wmetrics/src/app"
 	"github.com/vpominchuk/wmetrics/src/formatter"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 )
@@ -69,6 +70,21 @@ func Validate(arguments Arguments) error {
 
 	if err := validateUrlListFile(*arguments.URLListFile.Value); err != nil {
 		return err
+	}
+
+	if arguments.ExitWithErrorOnCode.Value != nil && len(*arguments.ExitWithErrorOnCode.Value) > 0 {
+		pattern := "(?i)^([0-9]{1,3}|[0-9]{1}xx)$"
+		re, err := regexp.Compile(pattern)
+
+		if err != nil {
+			return fmt.Errorf("invalid exit with error on code pattern: %s", pattern)
+		}
+
+		for _, code := range *arguments.ExitWithErrorOnCode.Value {
+			if !re.MatchString(code) {
+				return fmt.Errorf("invalid exit with error on code: %s", code)
+			}
+		}
 	}
 
 	return nil

--- a/src/formatter/formatter.go
+++ b/src/formatter/formatter.go
@@ -188,9 +188,9 @@ func StrPadRight(string string, count int) string {
 func printDurations(title string, avg, median, min, max string, strLength int) {
 	fmt.Println(
 		StrPadRight(title, strLength) +
-			StrPadRight(fmt.Sprintf("%s", avg), 15) +
-			StrPadRight(fmt.Sprintf("%s", median), 15) +
-			StrPadRight(fmt.Sprintf("%s", min), 15) +
-			StrPadRight(fmt.Sprintf("%s", max), 15),
+			StrPadRight(avg, 15) +
+			StrPadRight(median, 15) +
+			StrPadRight(min, 15) +
+			StrPadRight(max, 15),
 	)
 }

--- a/src/helpers/helpers.go
+++ b/src/helpers/helpers.go
@@ -1,0 +1,13 @@
+package helpers
+
+import "regexp"
+
+func RegexpStringMatch(pattern string, subject string) (bool, error) {
+	re, err := regexp.Compile(pattern)
+
+	if err != nil {
+		return false, err
+	}
+
+	return re.MatchString(subject), nil
+}

--- a/src/tester/errors.go
+++ b/src/tester/errors.go
@@ -19,3 +19,11 @@ type PostDataFileError struct {
 func (r *PostDataFileError) Error() string {
 	return fmt.Sprintf("[%s], %v", r.FileName, r.Err)
 }
+
+type HttpCodeError struct {
+	Err error
+}
+
+func (r *HttpCodeError) Error() string {
+	return fmt.Sprintf("Error: %v", r.Err)
+}

--- a/src/tester/types.go
+++ b/src/tester/types.go
@@ -35,6 +35,7 @@ type Parameters struct {
 	CustomHeaders         []string
 	TimeLimit             time.Duration
 	URLListFile           string
+	ExitWithErrorOnCode   []string
 }
 
 type TestEngine interface {


### PR DESCRIPTION
Exit with exit code 1 on certain HTTP codes or connection errors.
Adds a new command option: -e

```
./wmetrics -e 500 -e 4xx https://example.com/
```